### PR TITLE
Network Credentials override, fixes Uncatchable exceptions

### DIFF
--- a/NtlmProxy/NtlmProxy.cs
+++ b/NtlmProxy/NtlmProxy.cs
@@ -85,8 +85,9 @@ namespace MikeRogers.NtlmProxy
         /// <returns>A task thread that resolves into an HTTP response.</returns>
         private async Task<HttpResponseMessage> ProcessRequest(HttpListenerContext context)
         {
-            var credential = CredentialCache.DefaultNetworkCredentials;
-            var myCache = new CredentialCache
+			var credential = _options.NetworkCredentials ?? CredentialCache.DefaultNetworkCredentials;
+
+			var myCache = new CredentialCache
             {
                 {_hostname, "NTLM", credential}
             };

--- a/NtlmProxy/NtlmProxy.cs
+++ b/NtlmProxy/NtlmProxy.cs
@@ -85,9 +85,9 @@ namespace MikeRogers.NtlmProxy
         /// <returns>A task thread that resolves into an HTTP response.</returns>
         private async Task<HttpResponseMessage> ProcessRequest(HttpListenerContext context)
         {
-			var credential = _options.NetworkCredentials ?? CredentialCache.DefaultNetworkCredentials;
+            var credential = _options.NetworkCredentials ?? CredentialCache.DefaultNetworkCredentials;
 
-			var myCache = new CredentialCache
+            var myCache = new CredentialCache
             {
                 {_hostname, "NTLM", credential}
             };

--- a/NtlmProxy/SimpleHttpServer.cs
+++ b/NtlmProxy/SimpleHttpServer.cs
@@ -72,7 +72,7 @@ namespace MikeRogers.NtlmProxy
             _listener.Start();
 
 			// Managed tasks enables catchable exceptions
-            Task.Run(StartListenLoop);
+            Task.Run<Task>(() => StartListenLoop());
         }
 
         #endregion

--- a/NtlmProxy/SimpleHttpServer.cs
+++ b/NtlmProxy/SimpleHttpServer.cs
@@ -70,7 +70,9 @@ namespace MikeRogers.NtlmProxy
             _listener.Prefixes.Add(string.Format("http://localhost:{0}/", Port.ToString(CultureInfo.InvariantCulture)));
 
             _listener.Start();
-            StartListenLoop();
+
+			// Managed tasks enables catchable exceptions
+            Task.Run(StartListenLoop);
         }
 
         #endregion
@@ -108,7 +110,7 @@ namespace MikeRogers.NtlmProxy
         /// <summary>
         /// Starts the listen loop.
         /// </summary>
-        private async void StartListenLoop()
+        private async Task StartListenLoop()
         {
             while (true)
             {

--- a/NtlmProxy/SimpleHttpServer.cs
+++ b/NtlmProxy/SimpleHttpServer.cs
@@ -71,7 +71,7 @@ namespace MikeRogers.NtlmProxy
 
             _listener.Start();
 
-			// Managed tasks enables catchable exceptions
+            // Managed tasks enables catchable exceptions
             Task.Run<Task>(() => StartListenLoop());
         }
 

--- a/NtlmProxy/SimpleHttpServerOptions.cs
+++ b/NtlmProxy/SimpleHttpServerOptions.cs
@@ -42,7 +42,12 @@ namespace MikeRogers.NtlmProxy
         /// </summary>
         public List<string> ExcludedHeaders { get; private set; }
 
-        /// <summary>
+		/// <summary>
+		/// Optional ovverides default credentials with explicit network credentials
+		/// </summary>
+	    public NetworkCredential NetworkCredentials { get; set; }
+
+	    /// <summary>
         /// Initializes a new instance of the <see cref="SimpleHttpServerOptions"/> class.
         /// </summary>
         public SimpleHttpServerOptions()

--- a/NtlmProxy/SimpleHttpServerOptions.cs
+++ b/NtlmProxy/SimpleHttpServerOptions.cs
@@ -42,12 +42,12 @@ namespace MikeRogers.NtlmProxy
         /// </summary>
         public List<string> ExcludedHeaders { get; private set; }
 
-		/// <summary>
-		/// Optional ovverides default credentials with explicit network credentials
-		/// </summary>
-	    public NetworkCredential NetworkCredentials { get; set; }
+        /// <summary>
+        /// Optional ovverides default credentials with explicit network credentials
+        /// </summary>
+        public NetworkCredential NetworkCredentials { get; set; }
 
-	    /// <summary>
+        /// <summary>
         /// Initializes a new instance of the <see cref="SimpleHttpServerOptions"/> class.
         /// </summary>
         public SimpleHttpServerOptions()


### PR DESCRIPTION
- Adds possibility to ovverride Default NetworkCredentials (In cases where context Impersonation is not an option. Like in my case.)
- Fixes uncatchable exceptions in Server loop (I frequently get an `System.Net.HttpListenerException` at [_listener.GetContextAsync()](https://github.com/mike-rogers/NtlmProxy/blob/983f2b23d1f72c2307fde8f71635e90b80a39546/NtlmProxy/SimpleHttpServer.cs#L115); when PhantomJs webdriver is shutting down, which I dont care about but I cannot catch,  a change of method declaration fixed this problem)
