### PR TITLE
Fixed Async Code

### DIFF
--- a/NtlmProxy.Tests/NtlmProxy.Tests.csproj
+++ b/NtlmProxy.Tests/NtlmProxy.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,7 @@
     <AssemblyName>MikeRogers.NtlmProxy.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>d5f83b44</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -38,8 +40,9 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="RestSharp">
       <HintPath>..\packages\RestSharp.104.4.0\lib\net4\RestSharp.dll</HintPath>
@@ -64,6 +67,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/NtlmProxy.Tests/packages.config
+++ b/NtlmProxy.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnit" version="3.11.0" targetFramework="net45" />
   <package id="RestSharp" version="104.4.0" targetFramework="net45" />
 </packages>

--- a/NtlmProxy/MikeRogers.NtlmProxy.nuspec
+++ b/NtlmProxy/MikeRogers.NtlmProxy.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>MikeRogers.NtlmProxy</id>
-    <version>1.2.1.0</version>
+    <version>1.2.2.0</version>
     <title>NtlmProxy Library</title>
     <authors>Mike Rogers</authors>
     <owners>Mike Rogers</owners>
@@ -12,6 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Provides a proxy that adds NTLM data for the current user, for use on systems requiring NTLM</description>
     <releaseNotes>
+	  1.2.2 - Fixed Bug in Disposal of HttpListener, made ListenerLoop Cancellable
       1.2.1 - Addressed bug (issue #3), allowing dynamic configuration of proxy port
               number
       1.2 --- Added support for proxying options, including


### PR DESCRIPTION
@mike-rogers I kept getting a `System.Net.HttpListenerException (0x80004005): The I/O operation has been aborted because of either a thread exit or an application request` exception on Disposal of `NtlmProxy`, I found that `SimpleHttpServer.StartListenLoop` was not being cleaned up on `SimpleHttpServer` Disposal. So I added a `CancellationToken` for do this in an `async` manner. 

I also fixed `ExecuteTestInContext` in `NtlmProxyTests` to make it `async` an I alos updated to the latest Nunit